### PR TITLE
fix: modify rosetta to accept longer filenames

### DIFF
--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -37,7 +37,6 @@ import os
 import os.path
 import sys
 # Third-party packages
-import dask
 from distributed import Client, LocalCluster
 
 
@@ -595,7 +594,7 @@ def main():
                 chain, wtr, numr, mutr = mut_name.split(COMP_SEP)
 
             # If something went wrong, report it
-            except Exception as e:
+            except Exception:
                 
                 errstr = \
                     f"Could not generate MutateX-compatible " \

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -39,6 +39,11 @@ import sys
 # Third-party packages
 import dask
 from distributed import Client, LocalCluster
+
+
+import hashlib
+import json
+
 import pandas as pd
 # RosettaDDGProtocols
 from . import aggregation 
@@ -416,9 +421,6 @@ def main():
 
         # Get the mutation directory path
         mut_path = os.path.join(step_run_dir_path, dir_name)
-
-        import hashlib
-        import json
 
         print(f"The mut_path is: {mut_path}\n")
         print(f"The dir_name is: {dir_name}")

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -438,14 +438,13 @@ def main():
 
         hash_dict = {original: hashed}
     
-        # Write the dictionary to an output file, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
-        with open(f"{mut_path}/mutation_string_hash.json", 'w') as f:
-            try :
-                json.dump(hash_dict, f, indent=4)
-            except Exception as e:
-                errstr = f"Could not write the dictionary to the file: {e}"
-                log.error(errstr)
-                sys.exit(errstr)
+        # Check for the hashed directory create during the run process, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
+        try:
+            os.path.isdir(hashed)
+        except Exception as e:
+            errstr = f"Could not find the hashed directory {hashed}: {e}"
+            log.error(errstr)
+            sys.exit(errstr)
 
         # If the protocol is a cartddg protocol
         if family in ("cartddg", "cartddg2020"):

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -40,7 +40,6 @@ import sys
 # Third-party packages
 from distributed import Client, LocalCluster
 
-
 from hashlib import sha256
 
 import pandas as pd

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -40,7 +40,7 @@ import sys
 # Third-party packages
 from distributed import Client, LocalCluster
 
-from hashlib import sha256
+from hashlib import sha256 as hash_func
 
 import pandas as pd
 # RosettaDDGProtocols
@@ -414,8 +414,6 @@ def main():
 
 
     # For each mutation
-    hash_func = sha256
-
     for _, (mut_name, dir_name, mut_label, pos_label) \
         in mutinfo.iterrows():
 

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -437,10 +437,8 @@ def main():
         hashed = mut_path
   
         # Check for the hashed directory create during the run process, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
-        try:
-            os.path.isdir(hashed)
-        except Exception as e:
-            errstr = f"Could not find the hashed directory {hashed}: {e}"
+        if not os.path.isdir(hashed):
+            errstr = f"Could not find the hashed directory {hashed}"
             log.error(errstr)
             sys.exit(errstr)
 

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -41,7 +41,6 @@ from distributed import Client, LocalCluster
 
 
 from hashlib import sha256
-import json
 
 import pandas as pd
 # RosettaDDGProtocols

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -435,9 +435,7 @@ def main():
         mut_path = os.path.join(step_run_dir_path, hex_dig)
         log.info("The new mut_path is: %s",mut_path)
         hashed = mut_path
-
-        hash_dict = {original: hashed}
-    
+  
         # Check for the hashed directory create during the run process, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
         try:
             os.path.isdir(hashed)

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -417,13 +417,11 @@ def main():
     # For each mutation
     hash_func = sha256
 
-    for i, (mut_name, dir_name, mut_label, pos_label) \
+    for _, (mut_name, dir_name, mut_label, pos_label) \
         in mutinfo.iterrows():
 
         # Get the mutation directory path
         mut_path = os.path.join(step_run_dir_path, dir_name)
-
-        original = mut_path
 
         # Change the mut_path
         mut_path_hash = hash_func(dir_name.encode()) # should be the same as the hash from rosetta_ddg_run

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -595,13 +595,14 @@ def main():
                 chain, wtr, numr, mutr = mut_name.split(COMP_SEP)
 
             # If something went wrong, report it
-            except Exception:
+            except Exception as e:
                 
                 errstr = \
                     f"Could not generate MutateX-compatible " \
                     f"outputs for the mutation {mut_name}. " \
                     f"Please note that the conversion does not " \
-                    f"work for multiple simultaneous mutations. "
+                    f"work for multiple simultaneous mutations. " \
+                    f"{e}"
                 log.error(errstr)
                 continue
             

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -35,6 +35,7 @@ import collections
 import logging as log
 import os
 import os.path
+import re
 import sys
 # Third-party packages
 from distributed import Client, LocalCluster
@@ -546,7 +547,7 @@ def main():
                     dg_mut = dg_mut,
                     ddg = ddg,
                     mutation = mut_name,
-                    mut_label = mut_label,
+                    mut_label = re.sub(r':.', '_', mut_name).replace('.', '')[1:],
                     pos_label = pos_label,
                     rescale = rescale,
                     list_contributions = list_contributions,

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -443,7 +443,7 @@ def main():
                 json.dump(hash_dict, f, indent=4)
             except Exception as e:
                 errstr = f"Could not write the dictionary to the file: {e}"
-                log.error(f"Could not write the dictionary to the file: {e}")
+                log.error(errstr)
                 sys.exit(errstr)
 
         # If the protocol is a cartddg protocol

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -419,7 +419,6 @@ def main():
 
         import hashlib
         import json
-        from pathlib import Path
 
         print(f"The mut_path is: {mut_path}\n")
         print(f"The dir_name is: {dir_name}")

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -413,9 +413,33 @@ def main():
     # For each mutation
     for i, (mut_name, dir_name, mut_label, pos_label) \
         in mutinfo.iterrows():
-        
+
         # Get the mutation directory path
         mut_path = os.path.join(step_run_dir_path, dir_name)
+
+        import hashlib
+        import json
+        from pathlib import Path
+
+        print(f"The mut_path is: {mut_path}\n")
+        print(f"The dir_name is: {dir_name}")
+        original = mut_path
+
+        # Try changing mut_path
+        mut_path_hash = hashlib.sha256(dir_name.encode()) # should be the same as the original hash
+        hex_dig = mut_path_hash.hexdigest()  # Use the hash as the filename
+
+        # Now use the hash as the mut_path
+        print(f"\nThis is the old mut_path: {mut_path}\n")
+
+        mut_path = os.path.join(step_run_dir_path, hex_dig)
+        print(f"This is the new mut_path: {mut_path}")
+        hashed = mut_path
+
+        hash_dict = {original: hashed}
+        # The directory should already exist from the rosetta_ddg_run, so try writing to a file within it without creating it first
+        with open(f"{mut_path}/test_writing_mut_wd_to_file_aggregate.json", 'w') as f:
+            json.dump(hash_dict, f, indent=4)
 
         # If the protocol is a cartddg protocol
         if family in ("cartddg", "cartddg2020"):
@@ -516,7 +540,8 @@ def main():
 
         # Try to generate the aggregated and all-structures dataframes
         try:
-            
+
+            mut_label = hashlib.sha256(mut_label.encode()).hexdigest()
             aggr_df, struct_df = \
                 client.submit(\
                     aggregation.generate_output_dataframes,

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -422,23 +422,22 @@ def main():
         # Get the mutation directory path
         mut_path = os.path.join(step_run_dir_path, dir_name)
 
-        print(f"The mut_path is: {mut_path}\n")
-        print(f"The dir_name is: {dir_name}")
         original = mut_path
 
-        # Try changing mut_path
+        # Change the mut_path
         mut_path_hash = hashlib.sha256(dir_name.encode()) # should be the same as the original hash
         hex_dig = mut_path_hash.hexdigest()  # Use the hash as the filename
 
-        # Now use the hash as the mut_path
-        print(f"\nThis is the old mut_path: {mut_path}\n")
+        # Use the hash as the mut_path
+        log.info("The old mut_path: %s", mut_path)
 
         mut_path = os.path.join(step_run_dir_path, hex_dig)
-        print(f"This is the new mut_path: {mut_path}")
+        log.info("The new mut_path is: %s",mut_path)
         hashed = mut_path
 
         hash_dict = {original: hashed}
-        # The directory should already exist from the rosetta_ddg_run, so try writing to a file within it without creating it first
+        # The directory should already exist from the rosetta_ddg_run
+        
         with open(f"{mut_path}/test_writing_mut_wd_to_file_aggregate.json", 'w') as f:
             json.dump(hash_dict, f, indent=4)
 

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -437,7 +437,7 @@ def main():
         hash_dict = {original: hashed}
     
         # Write the dictionary to an output file, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
-        with open(f"{mut_path}/test_writing_mut_wd_to_file_aggregate.json", 'w') as f:
+        with open(f"{mut_path}/mutation_string_hash.json", 'w') as f:
             try :
                 json.dump(hash_dict, f, indent=4)
             except Exception as e:

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -424,7 +424,7 @@ def main():
         original = mut_path
 
         # Change the mut_path
-        mut_path_hash = hashlib.sha256(dir_name.encode()) # should be the same as the original hash
+        mut_path_hash = hashlib.sha256(dir_name.encode()) # should be the same as the hash from rosetta_ddg_run
         hex_dig = mut_path_hash.hexdigest()  # Use the hash as the filename
 
         # Use the hash as the mut_path
@@ -435,8 +435,8 @@ def main():
         hashed = mut_path
 
         hash_dict = {original: hashed}
-        # The directory should already exist from the rosetta_ddg_run
-        
+    
+        # Write the dictionary to an output file, where the hashes should be the same when created by rosetta_ddg_run and rosetta_ddg_aggregate
         with open(f"{mut_path}/test_writing_mut_wd_to_file_aggregate.json", 'w') as f:
             try :
                 json.dump(hash_dict, f, indent=4)

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -539,7 +539,7 @@ def main():
 
         # Try to generate the aggregated and all-structures dataframes
         try:
-            mut_label = hashlib.sha256(mut_label.encode()).hexdigest()
+            mut_label = hash_func(mut_label.encode()).hexdigest()
             aggr_df, struct_df = \
                 client.submit(\
                     aggregation.generate_output_dataframes,

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -40,7 +40,7 @@ import sys
 from distributed import Client, LocalCluster
 
 
-import hashlib
+from hashlib import sha256
 import json
 
 import pandas as pd
@@ -415,6 +415,8 @@ def main():
 
 
     # For each mutation
+    hash_func = sha256
+
     for i, (mut_name, dir_name, mut_label, pos_label) \
         in mutinfo.iterrows():
 
@@ -424,7 +426,7 @@ def main():
         original = mut_path
 
         # Change the mut_path
-        mut_path_hash = hashlib.sha256(dir_name.encode()) # should be the same as the hash from rosetta_ddg_run
+        mut_path_hash = hash_func(dir_name.encode()) # should be the same as the hash from rosetta_ddg_run
         hex_dig = mut_path_hash.hexdigest()  # Use the hash as the filename
 
         # Use the hash as the mut_path
@@ -544,7 +546,6 @@ def main():
 
         # Try to generate the aggregated and all-structures dataframes
         try:
-
             mut_label = hashlib.sha256(mut_label.encode()).hexdigest()
             aggr_df, struct_df = \
                 client.submit(\

--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -439,7 +439,12 @@ def main():
         # The directory should already exist from the rosetta_ddg_run
         
         with open(f"{mut_path}/test_writing_mut_wd_to_file_aggregate.json", 'w') as f:
-            json.dump(hash_dict, f, indent=4)
+            try :
+                json.dump(hash_dict, f, indent=4)
+            except Exception as e:
+                errstr = f"Could not write the dictionary to the file: {e}"
+                log.error(f"Could not write the dictionary to the file: {e}")
+                sys.exit(errstr)
 
         # If the protocol is a cartddg protocol
         if family in ("cartddg", "cartddg2020"):

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -453,7 +453,7 @@ def main():
                     mut_wd = \
                         os.path.join(step_wd, mut_orig[MUT_DIR_PATH])
                     original_dir = mut_wd
-                    log.info("The mutation string as the direcoty will be converted to a hash")
+                    log.info("The mutation string as the directory will be converted to a hash")
                     log.info("The original mutation string is: %s", mut_orig[MUT_DIR_PATH])
 
                     mut_wd_hash = hashlib.sha256(mut_orig[MUT_DIR_PATH].encode())

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -467,7 +467,7 @@ def main():
                     # Create the new directory with the hash as the name
                     Path(mut_wd).mkdir(parents=True, exist_ok=True)
 
-                    with open(f"{mut_wd}/test_writing_mut_wd_to_file.json", 'w') as f:
+                    with open(f"{mut_wd}/mutation_string_hash.json", 'w') as f:
                         log.info("Writing original mutation string and hash to file")                        
                         json.dump(hash_dict, f, indent=4)
 

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -453,8 +453,8 @@ def main():
                     log.info("The mutation string as the directory will be converted to a hash")
                     log.info("The original mutation string is: %s", mut_orig[MUT_DIR_PATH])
 
-                    mut_wd_hash = hashlib.sha256(mut_orig[MUT_DIR_PATH].encode())
-                    hex_dig = mut_wd_hash.hexdigest()  # Use the hash as the filename
+                    # Use the hash as the filename
+                    hex_dig = hashlib.sha256(mut_orig[MUT_DIR_PATH].encode()).hexdigest()  
                     log.info("The hex digested hash is: %s", hex_dig)
 
                     # Use the hash as the mut_wd

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -38,13 +38,11 @@ import os.path
 from pathlib import Path
 import sys
 # Third-party packages
-import dask
 from distributed import (
     Client,
     fire_and_forget,
     LocalCluster
 )
-import yaml
 
 import hashlib
 import json
@@ -58,7 +56,6 @@ from .defaults import (
     MUT_DIR_PATH,
     ROSETTA_PROTOCOLS
 )
-from . import pythonsteps
 from . import util
 
 

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -44,7 +44,7 @@ from distributed import (
     LocalCluster
 )
 
-import hashlib
+from hashlib import sha256
 import json
 
 # RosettaDDGProtocols
@@ -444,6 +444,8 @@ def main():
                 log.info(logstr)
 
                 # For each mutation
+                hash_func = sha256
+
                 for mut, mut_orig in zip(mutations, mutations_original):
 
                     # Set the path to the mutation directory
@@ -454,7 +456,7 @@ def main():
                     log.info("The original mutation string is: %s", mut_orig[MUT_DIR_PATH])
 
                     # Use the hash as the filename
-                    hex_dig = hashlib.sha256(mut_orig[MUT_DIR_PATH].encode()).hexdigest()  
+                    hex_dig = hash_func(mut_orig[MUT_DIR_PATH].encode()).hexdigest()  
                     log.info("The hex digested hash is: %s", hex_dig)
 
                     # Use the hash as the mut_wd

--- a/RosettaDDGPrediction/rosetta_ddg_run.py
+++ b/RosettaDDGPrediction/rosetta_ddg_run.py
@@ -44,7 +44,7 @@ from distributed import (
     LocalCluster
 )
 
-from hashlib import sha256
+from hashlib import sha256 as hash_func
 import json
 
 # RosettaDDGProtocols
@@ -444,8 +444,6 @@ def main():
                 log.info(logstr)
 
                 # For each mutation
-                hash_func = sha256
-
                 for mut, mut_orig in zip(mutations, mutations_original):
 
                     # Set the path to the mutation directory


### PR DESCRIPTION
Rosetta currently creates files with filenames containing mutation strings. This sets a limit as to the number of simultaneous mutations to which predictions can be performed.

This PR modifies behavior to accept arbitrarily long filenames by converting mutation strings to a hash and using the hex digested string of the hash in the filename instead.